### PR TITLE
[docs] Require the removal of all non-CentOS base kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,16 @@ CentOS Linux 8. It does not support CentOS Stream.
 
 ## Before you switch
 
+<details>
+  <summary><strong>Remove all non-standard kernels</strong> i.e.  kernels that are not from either the CentOS <code>base</code> or <code>updates</code> repos. Click for more info.</summary>
+
+  > Because of the [GRUB2 BootHole](https://blogs.oracle.com/linux/cve-2020-10713-grub2-boothole) vulnerability, our SecureBoot shim can only boot kernels signed by Oracle and we can only replace the default CentOS kernels. While this may not have an impact if SecureBoot is currently disabled, enabling it at a later date could render the system unbootable. For that reason, we strongly recommend removing all non-standard kernels which includes the [`centosplus`](https://wiki.centos.org/AdditionalResources/Repositories/CentOSPlus) kernels.
+
+</details>
+
 1. Ensure your CentOS `yum` or `dnf` configuration is working, i.e. there are no
    stale repositories.
-1. Disable all non-CentOS repositories. You can re-enable them after the switch.
+1. Disable all non-CentOS repositories. You can re-enable the repos after the switch.
 1. Ensure you have at least 5GB of free space in `/var/cache`.
 1. All automatic updates, e.g. via `yum-cron` should be disabled.
 
@@ -32,6 +39,8 @@ CentOS Linux 8. It does not support CentOS Stream.
 1. Compatibility with packages installed from third-party repositories is
    expected but not guaranteed. Some software doesn't like the existence of an
    `/etc/oracle-release` file, for example.
+1. Packages that install third-party and/or closed-source kernel modules, e.g.
+   commercial anti-virus products, may not work after switching.
 1. The script only enables the base repositories required to enable switching
    to Oracle Linux. Users may need to enable additional repositories to obtain
    updates for packages already installed (see [issue #1](https://github.com/oracle/centos2ol/issues/1)).


### PR DESCRIPTION
Our SecureBoot shim can only boot Oracle signed kernels and
we can only switch the standard CentOS kernel versions to our
signed versions. So document the need to remove any non-CentOS
kernels before switching.

Signed-off-by: Avi Miller <avi.miller@oracle.com>