### PR TITLE
Use globbing when identifying release version

### DIFF
--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -102,12 +102,12 @@ case "$os_version" in
         new_releases=(oraclelinux-release oraclelinux-release-el8 redhat-release)
         base_packages=("${base_packages[@]}" plymouth grub2 grubby kernel-uek)
         ;;
-    7)
+    7*)
         repo_file=public-yum-ol7.repo
         new_releases=(oraclelinux-release oraclelinux-release-el7 redhat-release-server)
         base_packages=("${base_packages[@]}" plymouth grub2 grubby kernel-uek)
         ;;
-    6)
+    6*)
         repo_file=public-yum-ol6.repo
         new_releases=(oraclelinux-release oraclelinux-release-el6 redhat-release-server)
         base_packages=("${base_packages[@]}" oraclelinux-release-notes plymouth grub grubby kernel-uek)


### PR DESCRIPTION
We're inconsistent in identifying release versions, this can impact users attempting to rerun the script
```
$ for system in centos:6 centos:7 centos:8 oraclelinux:6 oraclelinux:7 oraclelinux:8; do 
echo ${system}
podman run -ti ${system} rpm -q --whatprovides redhat-release --qf "%{version}"
echo -e "\n---"
done

centos:6
6
---
centos:7
7
---
centos:8
8.3
---
oraclelinux:6
6Server
---
oraclelinux:7
7.9
---
oraclelinux:8
8.28.2
---

```

Signed-off-by: Mark Cram <mark.cram@oracle.com>