### PR TITLE
Automatically enable additional repositories to match CentOS equivalent

### DIFF
--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -323,14 +323,12 @@ trap - ERR
 case "$os_version" in
     6*)
         declare -A repositories=(
-            [base]="REPO ol6_u10_base"
             [base-debuginfo]="REPO https://oss.oracle.com/ol6/debuginfo/"
             [updates]="REPO ol6_latest"
         )
         ;;
     7*)
         declare -A repositories=(
-            [base]="REPO ol7_u9_base"
             [base-debuginfo]="REPO https://oss.oracle.com/ol7/debuginfo/"
             [updates]="REPO ol7_latest"
             [centos-ceph-jewel]="RPM oracle-ceph-release-el7"

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -380,7 +380,7 @@ for reponame in ${enabled_repos}; do
         elif [ "${action[0]}" == "RPM" ] ; then
             matching_rpm=${action[1]}
             echo "Installing ${matching_rpm} to get content that replaces ${reponame}"
-            yum install --assumeyes "${matching_rpm}"  --disablerepo "*" --enablerepo "ol*_latest"
+            yum --assumeyes --disablerepo "*" --enablerepo "ol*_latest" install "${matching_rpm}"
         fi
     fi
 done

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -365,7 +365,6 @@ for reponame in ${enabled_repos}; do
     # action[0] will be REPO or RPM
     # action[1] will be the repos details or the RPMs name
     IFS=" " read -r -a action <<< "${repositories[${reponame}]}"
-    # action=(${repositories[${reponame}]})
     if [[ -n ${action[0]} ]]; then
         if [ "${action[0]}" == "REPO" ] ; then
             matching_repo=${action[1]}

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -167,6 +167,31 @@ for dir in yum.YumBase().doConfigSetup(init_plugins=False).reposdir:
         ;;
 esac
 
+echo "Learning which repositories are enabled..."
+case "$os_version" in
+    8*)
+        enabled_repos=$(/usr/libexec/platform-python -c "
+import dnf
+
+base = dnf.Base()
+base.read_all_repos()
+for repo in base.repos.iter_enabled():
+  print(repo.id)
+")
+        ;;
+    *)
+        enabled_repos=$(python2 -c "
+import yum
+
+base = yum.YumBase()
+base.doConfigSetup(init_plugins=False)
+for repo in base.repos.listEnabled():
+  print repo
+")
+        ;;
+esac
+echo -e "Repositories enabled before update include:\n${enabled_repos}"
+
 if [ -z "${reposdir}" ]; then
     exit_message "Could not locate your repository directory."
 fi

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -12,6 +12,22 @@ unset CDPATH
 yum_url=https://yum.oracle.com
 contact_email=oraclelinux-info_ww_grp@oracle.com
 bad_packages=(centos-backgrounds centos-logos centos-release centos-release-cr desktop-backgrounds-basic \
+              centos-release-advanced-virtualization centos-release-ansible26 centos-release-ansible-27 \
+              centos-release-ansible-28 centos-release-ansible-29 centos-release-ansible-29 centos-release-azure \
+              centos-release-ceph-jewel centos-release-ceph-luminous centos-release-ceph-nautilus centos-release-ceph-nautilus \
+              centos-release-ceph-octopus centos-release-configmanagement centos-release-dotnet centos-release-fdio \
+              centos-release-gluster40 centos-release-gluster41 centos-release-gluster5 centos-release-gluster6 \
+              centos-release-gluster6 centos-release-gluster7 centos-release-gluster7 centos-release-gluster8 \
+              centos-release-gluster-legacy centos-release-messaging centos-release-nfs-ganesha28 centos-release-nfs-ganesha28 \
+              centos-release-nfs-ganesha30 centos-release-nfs-ganesha30 centos-release-nfv-common centos-release-nfv-common \
+              centos-release-nfv-openvswitch centos-release-openshift-origin centos-release-openstack-queens \
+              centos-release-openstack-rocky centos-release-openstack-stein centos-release-openstack-train centos-release-openstack-train \
+              centos-release-openstack-ussuri centos-release-opstools centos-release-ovirt42 centos-release-ovirt43 \
+              centos-release-ovirt44 centos-release-paas-common centos-release-qemu-ev centos-release-qpid-proton \
+              centos-release-rabbitmq-38 centos-release-samba411 centos-release-samba411 centos-release-samba412 \
+              centos-release-scl centos-release-scl-rh centos-release-storage-common centos-release-storage-common \
+              centos-release-virt-common centos-release-virt-common centos-release-xen centos-release-xen-410 \
+              centos-release-xen-412 centos-release-xen-46 centos-release-xen-48 centos-release-xen-common \
               libreport-centos libreport-plugin-mantisbt libreport-plugin-rhtsupport python3-syspurpose \
               python-oauth sl-logos yum-rhn-plugin)
 

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -13,20 +13,20 @@ yum_url=https://yum.oracle.com
 contact_email=oraclelinux-info_ww_grp@oracle.com
 bad_packages=(centos-backgrounds centos-logos centos-release centos-release-cr desktop-backgrounds-basic \
               centos-release-advanced-virtualization centos-release-ansible26 centos-release-ansible-27 \
-              centos-release-ansible-28 centos-release-ansible-29 centos-release-ansible-29 centos-release-azure \
-              centos-release-ceph-jewel centos-release-ceph-luminous centos-release-ceph-nautilus centos-release-ceph-nautilus \
+              centos-release-ansible-28 centos-release-ansible-29 centos-release-azure \
+              centos-release-ceph-jewel centos-release-ceph-luminous centos-release-ceph-nautilus \
               centos-release-ceph-octopus centos-release-configmanagement centos-release-dotnet centos-release-fdio \
-              centos-release-gluster40 centos-release-gluster41 centos-release-gluster5 centos-release-gluster6 \
-              centos-release-gluster6 centos-release-gluster7 centos-release-gluster7 centos-release-gluster8 \
-              centos-release-gluster-legacy centos-release-messaging centos-release-nfs-ganesha28 centos-release-nfs-ganesha28 \
-              centos-release-nfs-ganesha30 centos-release-nfs-ganesha30 centos-release-nfv-common centos-release-nfv-common \
+              centos-release-gluster40 centos-release-gluster41 centos-release-gluster5 \
+              centos-release-gluster6 centos-release-gluster7 centos-release-gluster8 \
+              centos-release-gluster-legacy centos-release-messaging centos-release-nfs-ganesha28 \
+              centos-release-nfs-ganesha30 centos-release-nfv-common \
               centos-release-nfv-openvswitch centos-release-openshift-origin centos-release-openstack-queens \
-              centos-release-openstack-rocky centos-release-openstack-stein centos-release-openstack-train centos-release-openstack-train \
+              centos-release-openstack-rocky centos-release-openstack-stein centos-release-openstack-train \
               centos-release-openstack-ussuri centos-release-opstools centos-release-ovirt42 centos-release-ovirt43 \
               centos-release-ovirt44 centos-release-paas-common centos-release-qemu-ev centos-release-qpid-proton \
-              centos-release-rabbitmq-38 centos-release-samba411 centos-release-samba411 centos-release-samba412 \
-              centos-release-scl centos-release-scl-rh centos-release-storage-common centos-release-storage-common \
-              centos-release-virt-common centos-release-virt-common centos-release-xen centos-release-xen-410 \
+              centos-release-rabbitmq-38 centos-release-samba411 centos-release-samba412 \
+              centos-release-scl centos-release-scl-rh centos-release-storage-common \
+              centos-release-virt-common centos-release-xen centos-release-xen-410 \
               centos-release-xen-412 centos-release-xen-46 centos-release-xen-48 centos-release-xen-common \
               libreport-centos libreport-plugin-mantisbt libreport-plugin-rhtsupport python3-syspurpose \
               python-oauth sl-logos yum-rhn-plugin)

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -281,7 +281,7 @@ echo "Backing up and removing old repository files..."
 # Identify repo files from the base OS
 rpm -ql "$old_release" | grep '\.repo$' > repo_files
 # Identify repo files from 'CentOS extras'
-if [ $(rpm -qa "centos-release-*" | wc -l) -gt 0 ] ; then
+if [ "$(rpm -qa "centos-release-*" | wc -l)" -gt 0 ] ; then
     rpm -qla "centos-release-*" | grep '\.repo$' >> repo_files
 fi
 while read -r repo; do
@@ -364,23 +364,24 @@ esac
 for reponame in ${enabled_repos}; do
     # action[0] will be REPO or RPM
     # action[1] will be the repos details or the RPMs name
-    action=(${repositories[${reponame}]})
+    IFS=" " read -r -a action <<< "${repositories[${reponame}]}"
+    # action=(${repositories[${reponame}]})
     if [[ -n ${action[0]} ]]; then
-        if [ ${action[0]} == "REPO" ] ; then
+        if [ "${action[0]}" == "REPO" ] ; then
             matching_repo=${action[1]}
             echo "Enabling ${matching_repo} which replaces ${reponame}"
             # An RPM that describes debuginfo repository does not exist
             #  check to see if the repo id starts with https, if it does then
             #  create a new repo pointing to the repository
             if [[ ${matching_repo} =~ https.* ]]; then
-                yum-config-manager --add-repo ${matching_repo}
+                yum-config-manager --add-repo "${matching_repo}"
             else
-                yum-config-manager --enable ${matching_repo}
+                yum-config-manager --enable "${matching_repo}"
             fi
-        elif [ ${action[0]} == "RPM" ] ; then
+        elif [ "${action[0]}" == "RPM" ] ; then
             matching_rpm=${action[1]}
             echo "Installing ${matching_rpm} to get content that replaces ${reponame}"
-            yum install -y ${matching_rpm}  --disablerepo "*" --enablerepo "ol*_latest"
+            yum install -y "${matching_rpm}"  --disablerepo "*" --enablerepo "ol*_latest"
         fi
     fi
 done

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -279,6 +279,7 @@ fi
 
 echo "Backing up and removing old repository files..."
 rpm -ql "$old_release" | grep '\.repo$' > repo_files
+rpm -qla "centos-release-*" | grep '\.repo$' >> repo_files
 while read -r repo; do
     if [ -f "$repo" ]; then
         cat - "$repo" > "$repo".disabled <<EOF

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -377,7 +377,7 @@ for reponame in ${enabled_repos}; do
         elif [ ${action[0]} == "RPM" ] ; then
             matching_rpm=${action[1]}
             echo "Installing ${matching_rpm} to get content that replaces ${reponame}"
-            yum install -y ${matching_rpm}
+            yum install -y ${matching_rpm}  --disablerepo "*" --enablerepo "ol*_latest"
         fi
     fi
 done

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -278,8 +278,12 @@ if [[ $old_release =~ ^centos-release-8.* ]] || [[ $old_release =~ ^centos-linux
 fi
 
 echo "Backing up and removing old repository files..."
+# Identify repo files from the base OS
 rpm -ql "$old_release" | grep '\.repo$' > repo_files
-rpm -qla "centos-release-*" | grep '\.repo$' >> repo_files
+# Identify repo files from 'CentOS extras'
+if [ $(rpm -qa "centos-release-*" | wc -l) -gt 0 ] ; then
+    rpm -qla "centos-release-*" | grep '\.repo$' >> repo_files
+fi
 while read -r repo; do
     if [ -f "$repo" ]; then
         cat - "$repo" > "$repo".disabled <<EOF

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -381,7 +381,7 @@ for reponame in ${enabled_repos}; do
         elif [ "${action[0]}" == "RPM" ] ; then
             matching_rpm=${action[1]}
             echo "Installing ${matching_rpm} to get content that replaces ${reponame}"
-            yum install -y "${matching_rpm}"  --disablerepo "*" --enablerepo "ol*_latest"
+            yum install --assumeyes "${matching_rpm}"  --disablerepo "*" --enablerepo "ol*_latest"
         fi
     fi
 done


### PR DESCRIPTION
Tested with CentOS 6/7/8 under a few different circumstances of 'extras' RPMs installed and software collections present.
The coverage of mapping non-base CentOS content to Oracle Linux isn't perfect but it's a good start.

Until we get #15  merged in some aspects will need manual fixes e.g. llvm-toolset used by CodereadyBuilder will need a user to reset and install llvm-toolset. 

This resolves #1 

Signed-off-by: Mark Cram <mark.cram@oracle.com>