### PR TITLE
Switch distro-specific module streams

### DIFF
--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -305,8 +305,8 @@ case "$os_version" in
     8*)
         # There are a few dnf modules that are named after the distribution
         #  for each steam named 'rhel' or 'rhel8' perform a module reset and install
-        modules_enabled=($(dnf module list --enabled | grep rhel | cut -f1 -d\  ))
-        if [[ "${modules_enabled[@]}" ]]; then
+        mapfile -t modules_enabled < <(dnf module list --enabled | grep rhel | cut -f1 -d\  )
+        if [[ "${modules_enabled[*]}" ]]; then
             for module in "${modules_enabled[@]}"; do
                 dnf module reset -y "${module}"
                 case ${module} in

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -306,21 +306,23 @@ case "$os_version" in
         # There are a few dnf modules that are named after the distribution
         #  for each steam named 'rhel' or 'rhel8' perform a module reset and install
         modules_enabled=($(dnf module list --enabled | grep rhel | cut -f1 -d\  ))
-        for module in "${modules_enabled[@]}"; do
-            dnf module reset -y "${module}"
-            case ${module} in
-            container-tools|go-toolset|jmc|llvm-toolset|rust-toolset)
-                dnf module install -y "${module}":ol8
-                ;;
-            virt)
-                dnf module install -y "${module}":ol
-                ;;
-            *)
-                echo "Unsure how to transform module ${module}"
-                ;;
-            esac
+        if [[ "${modules_enabled[@]}" ]]; then
+            for module in "${modules_enabled[@]}"; do
+                dnf module reset -y "${module}"
+                case ${module} in
+                container-tools|go-toolset|jmc|llvm-toolset|rust-toolset)
+                    dnf module install -y "${module}":ol8
+                    ;;
+                virt)
+                    dnf module install -y "${module}":ol
+                    ;;
+                *)
+                    echo "Unsure how to transform module ${module}"
+                    ;;
+                esac
+            done
             dnf update -y --disablerepo "*" --enablerepo "ol8_appstream"
-        done
+        fi
 
         # Two logo RPMs aren't currently covered by 'replaces' metadata, replace by hand.
         if rpm -q centos-logos-ipa; then

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -155,7 +155,7 @@ if [[ "$os_version" =~ 8.* ]]; then
                 container-tools|go-toolset|jmc|llvm-toolset|rust-toolset|virt)
                     ;;
                 *)
-                    echo "This tool is unable to automatically switch module ${module} from a CentOS 'rhel' stream to
+                    echo "This tool is unable to automatically switch module '${module}' from a CentOS 'rhel' stream to
 an Oracle Linux equivalent. Do you want to continue and resolve it manually?
 You may want select No to stop and raise an issue on ${github_url} or contact <${contact_email}> for advice."
                     select yn in "Yes" "No"; do
@@ -164,7 +164,7 @@ You may want select No to stop and raise an issue on ${github_url} or contact <$
                                 break
                                 ;;
                             No )
-                                exit_message "Unsure how to process module ${module}"
+                                exit_message "Unsure how to switch module '${module}'. Exiting as requested"
                                 ;;
                         esac
                     done

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -157,7 +157,7 @@ if [[ "$os_version" =~ 8.* ]]; then
                 *)
                     echo "This tool is unable to automatically switch module '${module}' from a CentOS 'rhel' stream to
 an Oracle Linux equivalent. Do you want to continue and resolve it manually?
-You may want select No to stop and raise an issue on ${github_url} or contact <${contact_email}> for advice."
+You may want select No to stop and raise an issue on ${github_url} for advice."
                     select yn in "Yes" "No"; do
                         case $yn in
                             Yes )

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -319,6 +319,7 @@ case "$os_version" in
                 echo "Unsure how to transform module ${module}"
                 ;;
             esac
+            dnf update -y --disablerepo "*" --enablerepo "ol8_appstream"
         done
 
         # Two logo RPMs aren't currently covered by 'replaces' metadata, replace by hand.

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -173,7 +173,8 @@ You may want select No to stop and raise an issue on ${github_url} for advice."
                         break
                         ;;
                     No )
-                        exit_message "Unsure how to switch module(s) '${unknown_modules[*]}'. Exiting as requested"
+                        echo "Unsure how to switch module(s) '${unknown_modules[*]}'. Exiting as requested"
+                        exit 1
                         ;;
                 esac
             done

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -305,7 +305,7 @@ case "$os_version" in
     8*)
         # There are a few dnf modules that are named after the distribution
         #  for each steam named 'rhel' or 'rhel8' perform a module reset and install
-        mapfile -t modules_enabled < <(dnf module list --enabled | grep rhel | cut -f1 -d\  )
+        mapfile -t modules_enabled < <(dnf module list --enabled | grep rhel | awk '{print $1}')
         if [[ "${modules_enabled[*]}" ]]; then
             for module in "${modules_enabled[@]}"; do
                 dnf module reset -y "${module}"
@@ -321,7 +321,7 @@ case "$os_version" in
                     ;;
                 esac
             done
-            dnf update -y --disablerepo "*" --enablerepo "ol8_appstream"
+            dnf --assumeyes --disablerepo "*" --enablerepo "ol8_appstream" update
         fi
 
         # Two logo RPMs aren't currently covered by 'replaces' metadata, replace by hand.

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -305,16 +305,15 @@ case "$os_version" in
     8*)
         # There are a few dnf modules that are named after the distribution
         #  for each steam named 'rhel' or 'rhel8' perform a module reset and install
-        modules_enabled=$(dnf module list --enabled | grep rhel | cut -f1 -d\  )
-        # Workaround for qemu-guest-agent packages installed from virt modules
-        for module in ${modules_enabled[@]}; do
-            dnf module reset -y ${module}
+        modules_enabled=($(dnf module list --enabled | grep rhel | cut -f1 -d\  ))
+        for module in "${modules_enabled[@]}"; do
+            dnf module reset -y "${module}"
             case ${module} in
             container-tools|go-toolset|jmc|llvm-toolset|rust-toolset)
-                dnf module install -y ${module}:ol8
+                dnf module install -y "${module}":ol8
                 ;;
             virt)
-                dnf module install -y virt:ol
+                dnf module install -y "${module}":ol
                 ;;
             *)
                 echo "Unsure how to transform module ${module}"


### PR DESCRIPTION
Some `dnf module`s are named after a distribution('rhel' or 'rhel8'). Switch them to to the 'ol' or 'ol8' equivalents. Resolves #8 

An example of CentOS8:
```
$ dnf module list | grep rhel
container-tools      rhel8 [d]   common [d]                               Common tools and dependencies for container runtimes                        
go-toolset           rhel8 [d]   common [d]                               Go                                                                          
jmc                  rhel8 [d]   common [d], core                         Java Mission Control is a profiling and diagnostics tool for the Hotspot JVM
llvm-toolset         rhel8 [d]   common [d]                               LLVM                                                                        
rust-toolset         rhel8 [d]   common [d]                               Rust                                                                        
virt                 rhel [d][e] common [d]                               Virtualization module
```

Signed-off-by: Mark Cram <mark.cram@oracle.com>