### PR TITLE
Delete dnf cache at end of switch

### DIFF
--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -344,6 +344,6 @@ case "$os_version" in
 esac
 
 echo "Removing yum cache"
-rm -rf /var/cache/yum
+rm -rf /var/cache/{yum,dnf}
 
 echo "Switch complete. Oracle recommends rebooting this system."


### PR DESCRIPTION
A second attempt to close #10.

I didn't test the whole script on CentOS 6/7/8 for this change but I did ensure the following worked on these platforms without issue 
```
set -e

echo "Removing yum cache"
rm -rf /var/cache/{yum,dnf}

echo "Switch complete. Oracle recommends rebooting this system."
```

Signed-off-by: Mark Cram <mark.cram@oracle.com>