### PR TITLE
Use full path for redhat-release when checking for a supported distribution

### DIFF
--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -90,7 +90,7 @@ for pkg in rpm yum curl; do
 done
 
 echo "Checking your distribution..."
-if ! old_release=$(rpm -q --whatprovides redhat-release); then
+if ! old_release=$(rpm -q --whatprovides /etc/redhat-release); then
     exit_message "You appear to be running an unsupported distribution."
 fi
 


### PR DESCRIPTION
The change in this PR does the following:

- Utilizes the full path to `redhat-release` when checking if the running distribution is supported

I have tested this on CentOS 6-8 and Oracle Linux 6-8. The conversion from CentOS to Oracle Linux was still functional and the script is now able to properly detect if the host it's running on is running Oracle Linux. This should fix #12 