### PR TITLE
[bug] Fix parameter handling

### DIFF
--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -87,7 +87,7 @@ reinstall_all_rpms=false
 
 verify_all_rpms=false
 
-while getopts "hr:V" option; do
+while getopts "hrV" option; do
     case "$option" in
         h) usage ;;
         r) reinstall_all_rpms=true ;;


### PR DESCRIPTION
None of the parameters require an argument, so there is no need
for a colon.

Fixes #32.

Signed-off-by: Avi Miller <avi.miller@oracle.com>