### PR TITLE
[bug] Remove the restore_repos() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ CentOS Linux 8. It does not support CentOS Stream.
 
 ## Before you switch
 
+**IMPORTANT:** this script is a work-in-progress and is not designed to handle
+all possible configurations. Please ensure you have a **complete backup** of the
+system _before_ you start this process in the event the script is unable to
+convert the system successfully.
+
 <details>
   <summary><strong>Remove all non-standard kernels</strong> i.e.  kernels that are not from either the CentOS <code>base</code> or <code>updates</code> repos. Click for more info.</summary>
 
@@ -39,7 +44,7 @@ CentOS Linux 8. It does not support CentOS Stream.
    Oracle Linux. This is not necessary for support and has no impact to a systems functionality
    but is offered so a user can remove CentOS GPG keys from the truststore.
    A list of all non-Oracle RPMs will be displayed after the reinstall process.
-   
+
 * `-V` Verify RPM information before and after the switch
 
    This option creates four output files:

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -61,17 +61,8 @@ exit_message() {
     exit 1
 } >&2
 
-restore_repos() {
-    yum remove -y "${new_releases[@]}"
-    find . -name 'repo.*' | while read -r repo; do
-        destination=$(head -n1 "$repo")
-        if [ "${destination}" ]; then
-            tail -n+2 "${repo}" > "${destination}"
-        fi
-    done
-    rm "${reposdir}/${repo_file}"
-    exit_message "Could not install Oracle Linux packages.
-Your repositories have been restored to your previous configuration."
+final_failure() {
+    echo "An error occurred while attempting to switch this system to Oracle Linux and it may be in an unstable/unbootable state. To avoid further issues, the script has terminated."
 }
 
 generate_rpms_info() {
@@ -331,7 +322,7 @@ if ! have_program yumdownloader; then
 fi
 
 cd "$(mktemp -d)"
-trap restore_repos ERR
+trap final_failure ERR
 
 # Most distros keep their /etc/yum.repos.d content in the -release rpm. CentOS 8 does not and the behaviour changes between
 #  minor releases; 8.0 uses 'centos-repos' while 8.3 uses 'centos-linux-repos', glob for simplicity.


### PR DESCRIPTION
The restore_repos() function had the ability to completely destroy
a system if called at the wrong point. Instead of attempting to restore
the system, a fatal error is better.

I've also added a note in the README reminding folks that taking a full
backup before trying to switch the system is a very good idea.

Fixes #35.

Signed-off-by: Avi Miller <avi.miller@oracle.com>