### PR TITLE
[fix] Update CODEOWNERS to refer to the maintainers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# Assign the maintainers to all reviews
-* @Djelibeybi @mark-au @totalamateurhour
+# Assign global ownership to the maintainers team
+*   @oracle/centos2ol-maintainers


### PR DESCRIPTION
This makes code ownership more flexible as users are added to
or removed from the team.

Signed-off-by: Avi Miller <avi.miller@oracle.com>