### PR TITLE
[bug] Disable explicit distroverpkg setting in /etc/yum.conf

### DIFF
--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -351,6 +351,12 @@ EOF
     fi
 done < repo_files
 
+# Disable the explicit distroverpkg as centos-release provides the correct value
+# for system-release(releasever).
+# See https://github.com/oracle/centos2ol/issues/53
+echo "Removing CentOS-specific yum configuration from /etc/yum.conf"
+sed -i.bak -e 's/^distroverpkg/#&/g' -e 's/^bugtracker_url/#&/g' /etc/yum.conf
+
 echo "Downloading Oracle Linux release package..."
 if ! yumdownloader "${new_releases[@]}"; then
     {


### PR DESCRIPTION
If /etc/yum.conf has been modified by the user, it will not be
replaced by the default version from Oracle Linux. Instead, an
rpmnew file is created. This results in yum being unable to
resolve the $releasever variable post-switch as the referenced
package is no longer installed.

Fixes #53.

Signed-off-by: Avi Miller <avi.miller@oracle.com>