### PR TITLE
[fix] Replace restore_repos with final_failure

### DIFF
--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -366,7 +366,7 @@ if ! yumdownloader "${new_releases[@]}"; then
         echo "Are you behind a proxy? If so, make sure the 'http_proxy' environment"
         echo "variable is set with your proxy address."
     } >&2
-    restore_repos
+    final_failure
 fi
 
 echo "Switching old release package with Oracle Linux..."


### PR DESCRIPTION
I missed this instance of restore_repos when I removed the function.
This fixes that oversight and also fixes #59.

Signed-off-by: Avi Miller <avi.miller@oracle.com>