### PR TITLE
Enable 'ol7_optional_latest repo' when 'updates' enabled

### DIFF
--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -469,22 +469,6 @@ fi
 
 echo "Switch successful. Syncing with Oracle Linux repositories."
 
-# It's possible that we had the same package in bad_packages (remove) and base_packages (install).
-# In this case yum/dnf will remove the package. To catch this we'll look for duplicates and perform
-# a second install
-for add_package in "${base_packages[@]}"; do
-    for remove_package in "${bad_packages[@]}"; do
-        if [[ ${add_package} == "${remove_package}" ]]; then
-            second_install_packages+=("${add_package}")
-        fi
-    done
-done
-if [ ${#second_install_packages[@]} -gt 0 ]; then
-    if ! yum -y install "${second_install_packages[@]}"; then
-        exit_message "Could not install packages: ${second_install_packages[*]}"
-        fi
-fi
-
 if ! yum -y distro-sync; then
     exit_message "Could not automatically sync with Oracle Linux repositories.
 Check the output of 'yum distro-sync' to manually resolve the issue."

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -153,9 +153,9 @@ declare -A packages_to_replace=(
 )
 # Switch RPMs if they're installed
 for package_name in "${!packages_to_replace[@]}"; do
-    if [ "$(rpm -q ${package_name})" ]; then
+    if rpm -q "${package_name}" ; then
         bad_packages+=("${package_name}")
-        new_releases+=("${packages_to_replace[${package_name}]}")
+        base_packages+=("${packages_to_replace[${package_name}]}")
     fi
 done
 

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -474,7 +474,7 @@ echo "Switch successful. Syncing with Oracle Linux repositories."
 # a second install
 for add_package in "${base_packages[@]}"; do
     for remove_package in "${bad_packages[@]}"; do
-        if ${add_package} == "${remove_package}"; then
+        if [[ ${add_package} == "${remove_package}" ]]; then
             second_install_packages+=("${add_package}")
         fi
     done

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -469,6 +469,22 @@ fi
 
 echo "Switch successful. Syncing with Oracle Linux repositories."
 
+# It's possible that we had the same package in bad_packages (remove) and base_packages (install).
+# In this case yum/dnf will remove the package. To catch this we'll look for duplicates and perform
+# a second install
+for add_package in "${base_packages[@]}"; do
+    for remove_package in "${bad_packages[@]}"; do
+        if ${add_package} == "${remove_package}"; then
+            second_install_packages+=("${add_package}")
+        fi
+    done
+done
+if [ ${#second_install_packages[@]} -gt 0 ]; then
+    if ! yum -y install "${second_install_packages[@]}"; then
+        exit_message "Could not install packages: ${second_install_packages[*]}"
+        fi
+fi
+
 if ! yum -y distro-sync; then
     exit_message "Could not automatically sync with Oracle Linux repositories.
 Check the output of 'yum distro-sync' to manually resolve the issue."

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -401,7 +401,7 @@ case "$os_version" in
     7*)
         declare -A repositories=(
             [base-debuginfo]="REPO https://oss.oracle.com/ol7/debuginfo/"
-            [updates]="REPO ol7_latest"
+            [updates]="REPO ol7_latest,ol7_optional_latest"
             [centos-ceph-jewel]="RPM oracle-ceph-release-el7"
             [centos-gluster41]="RPM oracle-gluster-release-el7"
             [centos-gluster5]="RPM oracle-gluster-release-el7"

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -125,6 +125,7 @@ case "${old_release}" in
 esac
 
 os_version=$(rpm -q "${old_release}" --qf "%{version}")
+major_os_version=${os_version:0:1}
 base_packages=(basesystem initscripts oracle-logos)
 case "$os_version" in
     8*)
@@ -148,7 +149,7 @@ esac
 # Some packages need to be replaced as part of switch
 # Store as key value, if the first RPM is found then it's removed and the associated RPM installed
 declare -A packages_to_replace=(
-    [epel-release]="oracle-epel-release-el${os_version}"
+    [epel-release]="oracle-epel-release-el${major_os_version}"
 )
 # Switch RPMs if they're installed
 for package_name in "${!packages_to_replace[@]}"; do

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -149,7 +149,6 @@ esac
 # Store as key value, if the first RPM is found then it's removed and the associated RPM installed
 declare -A packages_to_replace=(
     [epel-release]="oracle-epel-release-el${os_version}"
-    [tkinter]="tkinter"     # CentOS 7 version has hardcoded dependancy, remove and reinstall later
 )
 # Switch RPMs if they're installed
 for package_name in "${!packages_to_replace[@]}"; do

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -148,7 +148,7 @@ esac
 # Some packages need to be replaced as part of switch
 # Store as key value, if the first RPM is found then it's removed and the associated RPM installed
 declare -A packages_to_replace=(
-    [epel-release]="oracle-epel-release-el${old_version}"
+    [epel-release]="oracle-epel-release-el${os_version}"
     [tkinter]="tkinter"     # CentOS 7 version has hardcoded dependancy, remove and reinstall later
 )
 # Switch RPMs if they're installed


### PR DESCRIPTION
Resolves #61

RPM `tkinter-2.7.5-90.el7.x86_64` has a dependency on `python-2.7.5-90.el7`. Oracle Linux includes `2.7.5-90.0.1.el7` which breaks the upgrade. Remove the RPM `tkinter` to avoid upgrade failures. This may be reverted once `tkinter` removes the `=` dependency with a `<=` dependency

Signed-off-by: Mark Cram <mark.cram@oracle.com>