### PR TITLE
Add support for Rocky Linux 8

### DIFF
--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -369,7 +369,6 @@ rpm -ql "$old_release" | grep '\.repo$' > repo_files
 if [ "$(rpm -qa "centos-release-*" | wc -l)" -gt 0 ] ; then
     rpm -qla "centos-release-*" | grep '\.repo$' >> repo_files
 fi
-
 while read -r repo; do
     if [ -f "$repo" ]; then
         cat - "$repo" > "$repo".disabled <<EOF

--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -362,7 +362,6 @@ if [[ $old_release =~ ^rocky-release-8.* ]]; then
     old_release=$(rpm -qa rocky*repos)
 fi
 
-set -x
 echo "Backing up and removing old repository files..."
 # Identify repo files from the base OS
 rpm -ql "$old_release" | grep '\.repo$' > repo_files
@@ -384,7 +383,7 @@ EOF
         rm "$repo"
     fi
 done < repo_files
-set +x
+
 # Disable the explicit distroverpkg as centos-release provides the correct value
 # for system-release(releasever).
 # See https://github.com/oracle/centos2ol/issues/53


### PR DESCRIPTION
If you have Rocky Linux 8 this change will make it possible for you to migrate to Oracle Linux

https://github.com/oracle/centos2ol/issues/88