### PR TITLE
add support for centos8-stream

### DIFF
--- a/centos2ol.sh
+++ b/centos2ol.sh
@@ -127,7 +127,7 @@ fi
 
 case "${old_release}" in
     redhat-release*) ;;
-    centos-release* | centos-linux-release*) ;;
+    centos-release* | centos-linux-release* | centos-stream-release*) ;;
     rocky-release*) ;;
     sl-release*) ;;
     oraclelinux-release*|enterprise-release*)
@@ -354,7 +354,7 @@ trap final_failure ERR
 
 # Most distros keep their /etc/yum.repos.d content in the -release rpm. CentOS 8 does not and the behaviour changes between
 #  minor releases; 8.0 uses 'centos-repos' while 8.3 uses 'centos-linux-repos', glob for simplicity.
-if [[ $old_release =~ ^centos-release-8.* ]] || [[ $old_release =~ ^centos-linux-release-8.* ]]; then
+if [[ $old_release =~ ^centos-release-8.* ]] || [[ $old_release =~ ^centos-linux-release-8.* ]] || [[ $old_release =~ ^centos-stream-release-8.* ]]; then
     old_release=$(rpm -qa centos*repos)
 fi
 # Most distros keep their /etc/yum.repos.d content in the -release rpm. Rocky Linux 8 does not.


### PR DESCRIPTION
I recently tried to set up an Oracle Linux machine using WSL 2 and basing it off of the CentOS 8 version, but I ran into insurmountable issues (at least, for me) while trying to update/upgrade everything necessary due to the fact that CentOS 8 has reached its EOL as of a month ago and the suggestion is to use either CentOS 7 or CentOS 8-stream.  As such, I installed CentOS 8-stream instead and tried to run the script.

Looking into the script, I ran into an error stating that the distribution wasn't supported.  Since my understanding of CentOS 8-stream is that it is CentOS 8, but supported upstream (or something like that), I figured I'd try to use the script anyway to see if it would work.

Lo and behold, I tweaked two lines of the script to include the `-stream` postfix and it upgraded smoothly.

Could this support be added for the help of others who, like me, might need it?

Otherwise, I could create an issue instead stating my workarounds for it.